### PR TITLE
Bumps 401k calc to 22500 based on new guidance [MERGE AFTER 2022-12-15]

### DIFF
--- a/scripts/401k_contribution_calc
+++ b/scripts/401k_contribution_calc
@@ -14,7 +14,7 @@
 # TL;DR Tell your 401k administrator to get with the program and do deferral
 #       maximization.
 
-MAX_DEFERRABLE = (ENV['MAX_DEFERRABLE'] || 20_500.00).to_f
+MAX_DEFERRABLE = (ENV['MAX_DEFERRABLE'] || 22_500.00).to_f
 
 if ARGV.size <= 1
   me = File.basename($PROGRAM_NAME, File.extname($PROGRAM_NAME))


### PR DESCRIPTION
https://www.wsj.com/articles/inflation-causes-irs-to-raise-contribution-limits-for-401-k-s-and-iras-11666368024?st=gbyli7f3m4w05s4&reflink=share_mobilewebshare