### PR TITLE
Add script to rename Git branch from master to main

### DIFF
--- a/scripts/git-master-to-main.sh
+++ b/scripts/git-master-to-main.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -eu -o pipefail
+
 FROM_BRANCH="${1:-master}"
 TO_BRANCH="${2:-main}"
 REMOTE="${3:-origin}"


### PR DESCRIPTION
I still come across my own repos that are using master. Let's put this in a script so I don't have to remember or rely on searching.